### PR TITLE
adds required fields to example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ To use:
                 "testRunId": "342-233-221",
                 "pushGatewayUrl": "http://localhost:9091",
                 "environment": "qa"
+                "labels":
+                   - "performance-test"
+                   - "artillery.io"
             }
         }
       }


### PR DESCRIPTION
doesn't work if you don't specify labels in the config. 
This is the error you would get without labels:

```
/foobar/performance_tests/node_modules/prom-client/lib/registry.js:34
		const defaultLabelNames = Object.keys(this._defaultLabels);
		                                 ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
 ```